### PR TITLE
fix the installer issue when vars not define

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,7 +113,11 @@ if [ -f $ext_file ]; then
     rm $ext_file
 fi
 
-ext_vars=$(echo "$EXTENSION_JS_VARS" | jq -c '.')
+ext_vars="${EXTENSION_JS_VARS:-}"
+  if [ -n "${ext_vars}" ]; then
+   ext_vars=$(echo "$ext_vars" | jq -c '.')
+ fi
+
 
 download_extension
 install_extension

--- a/install.sh
+++ b/install.sh
@@ -114,9 +114,9 @@ if [ -f $ext_file ]; then
 fi
 
 ext_vars="${EXTENSION_JS_VARS:-}"
-  if [ -n "${ext_vars}" ]; then
-   ext_vars=$(echo "$ext_vars" | jq -c '.')
- fi
+if [ -n "${ext_vars}" ]; then
+    ext_vars=$(echo "$ext_vars" | jq -c '.')
+fi
 
 
 download_extension


### PR DESCRIPTION
Test without vars
- Should be able to install the extension successfully

Test with  vars
export EXTENSION_NAME=xxx
export EXTENSION_JS_VARS=xx
- Should be able to install the extension with J file successfully

 