### PR TITLE
Fix finalizer to exit with installation error code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,18 +13,18 @@ uptime_ms() {
 start_time=$(uptime_ms)
 
 finalizer() {
+    code=$?
     local dl="${download_dir:-}"
     if [ -d "$dl" ]; then
       rm -rf $dl
     fi
-    code=$?
     if [ $code -ne 0 ]; then
         echo "ERROR: failed to install $ext_name extension: error code: $code"
     fi
     end_time=$(uptime_ms)
     elapsed=$(( end_time-start_time ))
     echo "Elapsed Time: $elapsed ms"
-    exit 0
+    exit $code
 }
 trap finalizer EXIT
 


### PR DESCRIPTION
Ensure finalizer exits with the correct error code.

We've been using this for a while. We're now building a PCI compliant env, and network access is restricted. As this is today, if the curl fails, the `code` value is the result of the `rm`  And the installer exits w/ a 0 exit code always.

I think it's more correct to fail w/ the curl exit code so that we have a solid failure on the init container if the curl download fails