### PR TITLE
Fix: Update alpine base image to fix libcrypto3/libssl3 vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2
+FROM alpine:3.23.3
 
 ARG USER=ext-installer
 ENV HOME /home/$USER

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ spec:
           volumeMounts:
             - name: extensions
               mountPath: /tmp/extensions/
+      volumes:
+        - name: extensions
+          emptyDir: {}
 ```
 
 > [!NOTE]


### PR DESCRIPTION
This PR fixes the Trivy HIGH/CRITICAL vulnerabilities found in `quay.io/argoprojlabs/argocd-extension-installer:v0.0.9`.

**Image reference from Helm chart:**
repository: quay.io/argoprojlabs/argocd-extension-installer
tag: "v0.0.9"

### 1. Original Vulnerability Scan
Command:
`trivy image --severity HIGH,CRITICAL quay.io/argoprojlabs/argocd-extension-installer:v0.0.9`

Output:
```

Report Summary

┌────────────────────────────────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                                 Target                                 │  Type  │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ quay.io/argoprojlabs/argocd-extension-installer:v0.0.9 (alpine 3.22.2) │ alpine │        6        │    -    │
└────────────────────────────────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


quay.io/argoprojlabs/argocd-extension-installer:v0.0.9 (alpine 3.22.2)
======================================================================
Total: 6 (HIGH: 4, CRITICAL: 2)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                             │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2025-15467 │ CRITICAL │ fixed  │ 3.5.4-r0          │ 3.5.5-r0      │ openssl: OpenSSL: Remote code execution or Denial of Service │
│            │                │          │        │                   │               │ via oversized Initialization...                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-15467                   │
│            ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-69419 │ HIGH     │        │                   │               │ openssl: OpenSSL: Arbitrary code execution due to            │
│            │                │          │        │                   │               │ out-of-bounds write in PKCS#12 processing...                 │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-69419                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-69421 │          │        │                   │               │ openssl: OpenSSL: Denial of Service via malformed PKCS#12    │
│            │                │          │        │                   │               │ file processing                                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-69421                   │
├────────────┼────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2025-15467 │ CRITICAL │        │                   │               │ openssl: OpenSSL: Remote code execution or Denial of Service │
│            │                │          │        │                   │               │ via oversized Initialization...                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-15467                   │
│            ├────────────────┼──────────┤        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-69419 │ HIGH     │        │                   │               │ openssl: OpenSSL: Arbitrary code execution due to            │
│            │                │          │        │                   │               │ out-of-bounds write in PKCS#12 processing...                 │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-69419                   │
│            ├────────────────┤          │        │                   │               ├──────────────────────────────────────────────────────────────┤
│            │ CVE-2025-69421 │          │        │                   │               │ openssl: OpenSSL: Denial of Service via malformed PKCS#12    │
│            │                │          │        │                   │               │ file processing                                              │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2025-69421                   │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────────┘
```

### 2. The Fix
Updated the base image from `alpine:3.22.2` to `alpine:3.23.3` in the `Dockerfile`. This resolves the `libcrypto3` and `libssl3` vulnerabilities (CVE-2025-15467, etc.) present in the older Alpine version. The `RUN apk upgrade --no-cache` instruction remains to ensure any future package updates are applied during build.

Command:
`docker build -t argocd-ext-installer-fixed .`

### 3. Verification Scan
Command:
`trivy image --severity HIGH,CRITICAL argocd-ext-installer-fixed`

Output:
```

Report Summary

┌────────────────────────────────────────────┬────────┬─────────────────┬─────────┐
│                   Target                   │  Type  │ Vulnerabilities │ Secrets │
├────────────────────────────────────────────┼────────┼─────────────────┼─────────┤
│ argocd-ext-installer-fixed (alpine 3.23.3) │ alpine │        0        │    -    │
└────────────────────────────────────────────┴────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

```
