### PR TITLE
fix: remove debug flag -x from install.sh set options

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euox pipefail
+set -euo pipefail
 
 # will return the current system uptime in milliseconds
 uptime_ms() {


### PR DESCRIPTION
Fixes #46.

## Problem

`install.sh` opens with:

```sh
set -euox pipefail
```

The `-x` flag (xtrace) has been present since the very first commit (#1). It causes bash to print every command and its arguments to **stderr** before execution:

```
+ curl -Lf --max-time 30 https://github.com/.../extension.tar.gz -o /tmp/extension-XXXXXX/extension.tar.gz
+ tar -zxf extension.tar.gz
+ cp -Rf resources/ui /tmp/extensions/resources/
+ exit 0
```

This is a debug-only facility. Its unintended side-effect is that **log collectors classify all these lines as errors** because they arrive on stderr. With the Datadog agent (and likely others), every `argocd-server` pod restart floods the error log stream with trace output, generating alert noise for operators.

## Fix

Remove `-x`. The remaining flags `-euo pipefail` are sufficient for robust error handling:
- `-e`: exit immediately on error  
- `-u`: treat unset variables as errors  
- `-o pipefail`: propagate pipe failures

## Notes

- `test.sh` pipes Docker output through `2>&1`, so tests pass regardless of whether `-x` is present — the change does not affect test coverage.
- If xtrace output is desired for a specific debug session, operators can set `BASH_XTRACEFD` or prepend `set -x` locally without it being baked into the image.